### PR TITLE
Update datos.dart: add x-api-key header

### DIFF
--- a/lib/services/datos.dart
+++ b/lib/services/datos.dart
@@ -36,6 +36,7 @@ class Datos {
       'Accept': 'application/json; application/vnd.esios-api-v1+json',
       'Host': 'api.esios.ree.es',
       'Authorization': 'Token token="$token"',
+      'x-api-key': $token,
       'Cookie': '',
     };
     try {


### PR DESCRIPTION
Adaptación a cambios en cabecera de token comunicado por REE/SIOS: en lugar de Authorization: Token token=xxxx
se usará
x-api-key: xxxx.

Las dos cabeceras pueden coexistir para el periodo de migración.